### PR TITLE
Firefox 151 support webserial

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -70,7 +70,7 @@
 
       <esp-web-install-button manifest="manifest.json">
         <button slot="activate">Flash ASCII Aquarium</button>
-        <span slot="unsupported">Use Chrome or Edge on a desktop computer.</span>
+        <span slot="unsupported">Use Chrome, Edge or Firefox (version 151 or above) on a desktop computer.</span>
         <span slot="not-allowed">This page needs HTTPS to flash your CYD.</span>
       </esp-web-install-button>
 


### PR DESCRIPTION
https://blog.mozilla.org/en/firefox/firefox-web-serial-adafruit/

Tested with Firefox 151, I see the “Flash ASCII Aquarium” while on 150, it’s still a message encouraging another browser.