### PR TITLE
Fix display driver for ESP32-2432S028R CYD

### DIFF
--- a/User_Setup.h
+++ b/User_Setup.h
@@ -8,10 +8,8 @@
 #define USER_SETUP_ID 2432
 
 // Display driver
-#define ILI9341_DRIVER
-
-// Optional colour order (many CYD boards use BGR with ILI9341)
-#define TFT_RGB_ORDER TFT_BGR
+#define ILI9341_2_DRIVER
+#define TFT_INVERSION_ON
 
 // ESP32 TFT pin mapping (common ESP32-2432S028R board)
 #define TFT_MISO 12
@@ -28,6 +26,7 @@
 #define TFT_HEIGHT 240
 
 #define SPI_FREQUENCY       40000000
+//#define SPI_FREQUENCY       55000000
 #define SPI_READ_FREQUENCY  20000000
 #define SPI_TOUCH_FREQUENCY 2500000
 


### PR DESCRIPTION
## Summary
My particular CYD appears to use a variant of the ILI9341 chipset. That results in a garbled/flashing/scrambled image after flashing ASCII-Aquarium. To fix it, I do these steps:

- Switch `ILI9341_DRIVER` → `ILI9341_2_DRIVER` in `User_Setup.h`
- Add `TFT_INVERSION_ON` to match the actual panel variant on the ESP32-2432S028R board
- The previous config caused scrambled/blinking pixels on the right half of the display

## Test plan

- [ ] Flash and confirm display renders correctly with no scrambled pixels
- [ ] Verify colours look correct (black background, correct fish/seaweed colours)